### PR TITLE
Fix unresolved gsasl symbols

### DIFF
--- a/esasl/priv/Makefile.am
+++ b/esasl/priv/Makefile.am
@@ -6,6 +6,6 @@ AM_CPPFLAGS = $(GSASL_CFLAGS) $(EI_CFLAGS)
 privdir = $(ERLANG_INSTALL_LIB_DIR)/esasl-$(VERSION)/priv
 priv_PROGRAMS = gsasl_drv
 
-gsasl_drv_LDFLAGS = $(GSASL_LIBS) $(EI_LDFLAGS)
-gsasl_drv_LDADD = $(EI_LIBS)
+gsasl_drv_LDFLAGS = $(EI_LDFLAGS)
+gsasl_drv_LDADD = $(EI_LIBS) $(GSASL_LIBS)
 gsasl_drv_SOURCES = gsasl_drv.c port_util.h port_util.c


### PR DESCRIPTION
Seen with gcc Ubuntu/Linaro 4.6.1-9ubuntu3. Libraries should
appear at the end of the command line, after its users.

Signed-off-by: Andreas Oberritter obi@saftware.de
