### PR TITLE
Fix a memory leakage in esasl:loop/2

### DIFF
--- a/esasl/src/esasl.erl
+++ b/esasl/src/esasl.erl
@@ -313,9 +313,9 @@ loop(Port, Queue) ->
 	    erlang:port_close(Port),
 	    exit(normal);
 	Term ->
-	    ?ERROR("Unhandled term ~p~n", [Term])
-    end,
-    loop(Port, Queue).
+	    ?ERROR("Unhandled term ~p~n", [Term]),
+	    loop(Port, Queue)
+    end.
 
 
 %%====================================================================


### PR DESCRIPTION
The function wasn't doing a tail-call so every time it receives a message it was leaking stack memory.